### PR TITLE
Remove content-type header for FormData

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -30,9 +30,8 @@ function api(
   let payload: ApiBody | string | undefined = body;
 
   if (payload instanceof FormData) {
-    requestHeaders['Content-Type'] = 'multipart/form-data';
-  }
-  if (requestHeaders['Content-Type'] === 'application/json' && payload) {
+    delete requestHeaders['Content-Type'];
+  } else if (requestHeaders['Content-Type'] === 'application/json' && payload) {
     payload = JSON.stringify(payload);
   }
 


### PR DESCRIPTION
If omitted browser will correctly add file boundaries